### PR TITLE
Added option to define listen sections

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,23 +18,47 @@ haproxy_default_vars:
   - option tcplog
   - option dontlognull
 
-# Frontends
-haproxy_frontends:
-  - name: example
-    config:
-      - bind 10.10.10.10:443
-      - mode tcp
-      - default_backend example
-      - option tcplog
+# Frontend sections (check example below)
+haproxy_frontends: []
+# haproxy_frontends:
+#   - name: example_frontend
+#     config:
+#       - bind *:80
+#       - mode tcp
+#       - default_backend example_backend
+#       - option tcplog
 
-# Backends
-haproxy_backends:
-  - name: example
-    config:
-      - mode tcp
-      - balance roundrobin
-      - option httpchk GET /
-      - http-check expect status 200
-      - default-server inter 3s downinter 3s rise 2 fall 2 slowstart 60s
-      - server beta 10.10.10.11:443 check port 80
-      - server beta02 10.10.10.12:443 check port 80
+#   - name: stats
+#     config:
+#       - bind *:8404
+#       - mode http
+#       - stats enable
+#       - stats uri /stats
+#       - stats refresh 5s
+#       - stats admin if TRUE
+
+# Backend sections (check example below)
+haproxy_backends: []
+# haproxy_backends:
+#   - name: example_backend
+#     config:
+#       - mode tcp
+#       - balance roundrobin
+#       - option httpchk GET /
+#       - http-check expect status 200
+#       - default-server inter 3s downinter 3s rise 2 fall 2 slowstart 60s
+#       - server app1 10.10.10.11:80 check port 80
+#       - server app2 10.10.10.12:80 check port 80
+
+# Listen section (check example below)
+haproxy_listens: []
+# haproxy_listens:
+#   - name: example_listen
+#     config:
+#       - bind *:443
+#       - mode tcp
+#       - option tcplog
+#       - balance roundrobin
+#       - option httpchk GET /
+#       - server app1 10.10.10.21:443 check check-ssl
+#       - server app2 10.10.10.22:443 check check-ssl

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -18,6 +18,7 @@ defaults
   errorfile 504 /etc/haproxy/errors/504.http
 {% endif %}
 
+{% if haproxy_frontends | length > 0 %}
 {% for frontend in haproxy_frontends %}
 frontend {{ frontend.name }}
   {% for line in frontend.config %}
@@ -25,11 +26,23 @@ frontend {{ frontend.name }}
   {% endfor %}
 
 {% endfor %}
+{% endif %}
 
+{% if haproxy_backends | length > 0 %}
 {% for backend in haproxy_backends %}
 backend {{ backend.name }}
   {% for line in backend.config %}
   {{ line }}
-  {% endfor %}
 
+  {% endfor %}
 {% endfor %}
+{% endif %}
+
+{% if haproxy_listens | length > 0 %}
+{% for listen in haproxy_listens %}
+backend {{ listen.name }}
+  {% for line in listen.config %}
+  {{ line }}
+  {% endfor %}
+{% endfor %}
+{% endif %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -44,5 +44,6 @@ listen {{ listen.name }}
   {% for line in listen.config %}
   {{ line }}
   {% endfor %}
+
 {% endfor %}
 {% endif %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -40,7 +40,7 @@ backend {{ backend.name }}
 
 {% if haproxy_listens | length > 0 %}
 {% for listen in haproxy_listens %}
-backend {{ listen.name }}
+listen {{ listen.name }}
   {% for line in listen.config %}
   {{ line }}
   {% endfor %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -33,8 +33,8 @@ frontend {{ frontend.name }}
 backend {{ backend.name }}
   {% for line in backend.config %}
   {{ line }}
-
   {% endfor %}
+
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
# Pull Request Description
- Added option to define listen sections of HAProxy config
- Removed default _haproxy_frontends_ and  _haproxy_backends_ values, and added them as comments - examples of usage

## Change type
- [ ] Bug fix (non-breaking change which fixes a specific issue)
- [x] New feature (non-breaking change adding new functionality)
- [ ] Breaking change (fix or feature that potentially causes existing functionality to fail)
- [ ] Change that does not affect Ansible Role code (Github Actions Workflow, Documentation, or similair)

## How was this tested?
HAProxy 3.0 with a single _haproxy_listens_ section defined as well as multiple. 