### PR TITLE
Enable option to automatically install the latest version of HaProxy available

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -3,7 +3,7 @@ extends: default
 
 rules:
   line-length:
-    max: 150
+    max: 180
     level: warning
   comments:
     min-spaces-from-content: 1

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Ansible role to install/configure HAProxy on Debian based distros.
 - Ubuntu 22.04 LTS
 - Ubuntu 24.04 LTS
 
-NOTE: Should work on Debian too, but needs to be tested.
+Debian compatibility will be added in a future release.
 
 # Role Variables
 All settable variables with explanations and links are located in the defaults/main.yml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,9 @@
 # HAProxy version to install, according to HAProxy you should stick to versions/braches (for example 2.8.x or 2.9.x) and apply all patches,
 # for example 2.8.1, 2.8.2, etc. This variable follows that logic and passes the package to apt as "haproxy={{ haproxy_version }}.*"
 # For more info read https://github.com/haproxy/haproxy/blob/master/BRANCHES
-# haproxy_version: 2.8
+# If you set the haproxy_version to "latest" it will automatically find the latest version for your Ubuntu release and architecture.
+# haproxy_version: latest
+haproxy_version: 2.8
 
 # HAProxy package state
 haproxy_package_state: present

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # HAProxy version to install, according to HAProxy you should stick to versions/braches (for example 2.8.x or 2.9.x) and apply all patches,
 # for example 2.8.1, 2.8.2, etc. This variable follows that logic and passes the package to apt as "haproxy={{ haproxy_version }}.*"
 # For more info read https://github.com/haproxy/haproxy/blob/master/BRANCHES
-haproxy_version: 2.8
+# haproxy_version: 2.8
 
 # HAProxy package state
 haproxy_package_state: present

--- a/files/find_latest_haproxy.py
+++ b/files/find_latest_haproxy.py
@@ -17,7 +17,7 @@ for ppa in response_data["entries"]:
 
 if haproxy_ppas:
     haproxy_ppas.sort(reverse=True)
-    haproxy_version_latest = haproxy_ppas[0].split('-')[1].rstrip()
+    haproxy_version_latest = haproxy_ppas[0].split('-')[1].strip()
     print(haproxy_version_latest)
 else:
     raise Exception("No HAProxy PPAs found")

--- a/files/find_latest_haproxy.py
+++ b/files/find_latest_haproxy.py
@@ -1,0 +1,23 @@
+import urllib3
+import json
+
+http = urllib3.PoolManager()
+
+haproxy_ppas = []
+url = "https://api.launchpad.net/1.0/~vbernat/ppas"
+
+response = http.request('GET', url)
+if response.status != 200:
+    raise Exception(f"Request failed with status code {response.status}, response data: {response.data.decode('utf-8')}")
+
+response_data = json.loads(response.data.decode('utf-8'))
+for ppa in response_data["entries"]:
+    if ppa["name"].startswith("haproxy"):
+        haproxy_ppas.append(ppa["name"])
+
+if haproxy_ppas:
+    haproxy_ppas.sort(reverse=True)
+    haproxy_version_latest = haproxy_ppas[0].split('-')[1]
+    print(haproxy_version_latest)
+else:
+    raise Exception("No HAProxy PPAs found")

--- a/files/find_latest_haproxy.py
+++ b/files/find_latest_haproxy.py
@@ -11,6 +11,13 @@ arguments.add_argument(
     help="Ubuntu release name, e.g. 'noble'",
     required=True,
 )
+arguments.add_argument(
+    "--ubuntu-architecture",
+    dest="ubuntu_architecture",
+    type=str,
+    help="Ubuntu architecture, e.g. 'amd64'",
+    required=True,
+)
 arguments = arguments.parse_args()
 
 http = urllib3.PoolManager()
@@ -28,7 +35,7 @@ response_data = json.loads(response.data.decode('utf-8'))
 for ppa in response_data["entries"]:
     if ppa["name"].startswith("haproxy"):
         ppa_binaries_url = urljoin(
-            ppa["self_link"], f"?ws.op=getPublishedBinaries&status=Published&distro_arch_series=https://api.launchpad.net/1.0/ubuntu/{arguments.ubuntu_release_name}/amd64")
+            ppa["self_link"], f"?ws.op=getPublishedBinaries&status=Published&distro_arch_series=https://api.launchpad.net/1.0/ubuntu/{arguments.ubuntu_release_name}/{arguments.ubuntu_architecture}")
         ppa_binaries_response = http.request('GET', ppa_binaries_url)
         if ppa_binaries_response.status != 200:
             raise Exception(

--- a/files/find_latest_haproxy.py
+++ b/files/find_latest_haproxy.py
@@ -1,5 +1,17 @@
 import urllib3
 import json
+from urllib.parse import urljoin
+from argparse import ArgumentParser
+
+arguments = ArgumentParser()
+arguments.add_argument(
+    "--ubuntu-release-name",
+    dest="ubuntu_release_name",
+    type=str,
+    help="Ubuntu release name, e.g. 'noble'",
+    required=True,
+)
+arguments = arguments.parse_args()
 
 http = urllib3.PoolManager()
 
@@ -8,12 +20,23 @@ url = "https://api.launchpad.net/1.0/~vbernat/ppas"
 
 response = http.request('GET', url)
 if response.status != 200:
-    raise Exception(f"Request failed with status code {response.status}, response data: {response.data.decode('utf-8')}")
+    raise Exception(
+        f"Request failed with status code {response.status}, response data: {response.data.decode('utf-8')}")
 
 response_data = json.loads(response.data.decode('utf-8'))
+
 for ppa in response_data["entries"]:
     if ppa["name"].startswith("haproxy"):
-        haproxy_ppas.append(ppa["name"])
+        ppa_binaries_url = urljoin(
+            ppa["self_link"], f"?ws.op=getPublishedBinaries&status=Published&distro_arch_series=https://api.launchpad.net/1.0/ubuntu/{arguments.ubuntu_release_name}/amd64")
+        ppa_binaries_response = http.request('GET', ppa_binaries_url)
+        if ppa_binaries_response.status != 200:
+            raise Exception(
+                f"Request failed with status code {ppa_binaries_response.status}, response data: {ppa_binaries_response.data.decode('utf-8')}")
+        ppa_binaries_data = json.loads(
+            ppa_binaries_response.data.decode('utf-8'))
+        if ppa_binaries_data["total_size"] > 0:
+            haproxy_ppas.append(ppa["name"])
 
 if haproxy_ppas:
     haproxy_ppas.sort(reverse=True)

--- a/files/find_latest_haproxy.py
+++ b/files/find_latest_haproxy.py
@@ -17,7 +17,7 @@ for ppa in response_data["entries"]:
 
 if haproxy_ppas:
     haproxy_ppas.sort(reverse=True)
-    haproxy_version_latest = haproxy_ppas[0].split('-')[1]
+    haproxy_version_latest = haproxy_ppas[0].split('-')[1].rstrip()
     print(haproxy_version_latest)
 else:
     raise Exception("No HAProxy PPAs found")

--- a/files/find_latest_haproxy.py
+++ b/files/find_latest_haproxy.py
@@ -48,6 +48,6 @@ for ppa in response_data["entries"]:
 if haproxy_ppas:
     haproxy_ppas.sort(reverse=True)
     haproxy_version_latest = haproxy_ppas[0].split('-')[1].strip()
-    print(haproxy_version_latest.strip())
+    print(haproxy_version_latest)
 else:
     raise Exception("No HAProxy PPAs found")

--- a/files/find_latest_haproxy.py
+++ b/files/find_latest_haproxy.py
@@ -48,6 +48,6 @@ for ppa in response_data["entries"]:
 if haproxy_ppas:
     haproxy_ppas.sort(reverse=True)
     haproxy_version_latest = haproxy_ppas[0].split('-')[1].strip()
-    print(haproxy_version_latest)
+    print(haproxy_version_latest.strip())
 else:
     raise Exception("No HAProxy PPAs found")

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,25 +10,26 @@
   ansible.builtin.include_tasks:
     file: setup-Ubuntu.yml
   when: ansible_distribution == "Ubuntu"
-# - name: Install HAProxy
-#   ansible.builtin.apt:
-#     name: "haproxy={{ haproxy_version }}.*"
-#     state: "{{ haproxy_package_state }}"
-#     update_cache: true
 
-# - name: Copy HAProxy configuration
-#   ansible.builtin.template:
-#     src: haproxy.cfg.j2
-#     dest: /etc/haproxy/haproxy.cfg
-#     mode: "0644"
-#     validate: haproxy -f %s -c -q
-#     force: true
-#   notify: Reload HAProxy
-#   when: not haproxy_package_state == 'absent'
+- name: Install HAProxy
+  ansible.builtin.apt:
+    name: "haproxy={{ haproxy_version }}.*"
+    state: "{{ haproxy_package_state }}"
+    update_cache: true
 
-# - name: Ensure HAProxy is started and enabled at boot
-#   ansible.builtin.service:
-#     name: haproxy
-#     state: started
-#     enabled: true
-#   when: not haproxy_package_state == 'absent'
+- name: Copy HAProxy configuration
+  ansible.builtin.template:
+    src: haproxy.cfg.j2
+    dest: /etc/haproxy/haproxy.cfg
+    mode: "0644"
+    validate: haproxy -f %s -c -q
+    force: true
+  notify: Reload HAProxy
+  when: not haproxy_package_state == 'absent'
+
+- name: Ensure HAProxy is started and enabled at boot
+  ansible.builtin.service:
+    name: haproxy
+    state: started
+    enabled: true
+  when: not haproxy_package_state == 'absent'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,4 @@
 ---
-- name: Ensure dependencies are installed
-  ansible.builtin.apt:
-    name: software-properties-common
-    state: present
-    update_cache: true
-    cache_valid_time: 3600
-
 - name: Ubuntu specific tasks
   ansible.builtin.include_tasks:
     file: setup-Ubuntu.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,40 +6,29 @@
     update_cache: true
     cache_valid_time: 3600
 
-- name: Check if PPA present - vbernat/haproxy-{{ haproxy_version }}
-  ansible.builtin.shell: |
-    set -o pipefail
-    add-apt-repository --list | grep vbernat/haproxy-{{ haproxy_version }}
-  args:
-    executable: /bin/bash
-  failed_when: haproxy_repo_present.rc not in [0,1]
-  changed_when: false
-  register: haproxy_repo_present
+- name: Ubuntu specific tasks
+  ansible.builtin.include_tasks:
+    file: setup-Ubuntu.yml
+  when: ansible_distribution == "Ubuntu"
+# - name: Install HAProxy
+#   ansible.builtin.apt:
+#     name: "haproxy={{ haproxy_version }}.*"
+#     state: "{{ haproxy_package_state }}"
+#     update_cache: true
 
-- name: Add PPA vbernat/haproxy-{{ haproxy_version }}
-  ansible.builtin.command: add-apt-repository ppa:vbernat/haproxy-{{ haproxy_version }} -y
-  changed_when: true
-  when: haproxy_repo_present.stdout == ''
+# - name: Copy HAProxy configuration
+#   ansible.builtin.template:
+#     src: haproxy.cfg.j2
+#     dest: /etc/haproxy/haproxy.cfg
+#     mode: "0644"
+#     validate: haproxy -f %s -c -q
+#     force: true
+#   notify: Reload HAProxy
+#   when: not haproxy_package_state == 'absent'
 
-- name: Install HAProxy
-  ansible.builtin.apt:
-    name: "haproxy={{ haproxy_version }}.*"
-    state: "{{ haproxy_package_state }}"
-    update_cache: true
-
-- name: Copy HAProxy configuration
-  ansible.builtin.template:
-    src: haproxy.cfg.j2
-    dest: /etc/haproxy/haproxy.cfg
-    mode: "0644"
-    validate: haproxy -f %s -c -q
-    force: true
-  notify: Reload HAProxy
-  when: not haproxy_package_state == 'absent'
-
-- name: Ensure HAProxy is started and enabled at boot
-  ansible.builtin.service:
-    name: haproxy
-    state: started
-    enabled: true
-  when: not haproxy_package_state == 'absent'
+# - name: Ensure HAProxy is started and enabled at boot
+#   ansible.builtin.service:
+#     name: haproxy
+#     state: started
+#     enabled: true
+#   when: not haproxy_package_state == 'absent'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,7 @@
   ansible.builtin.apt:
     name: "haproxy={{ haproxy_version }}.*"
     state: "{{ haproxy_package_state }}"
+    allow_downgrade: true
     update_cache: true
 
 - name: Copy HAProxy configuration

--- a/tasks/setup-Ubuntu.yml
+++ b/tasks/setup-Ubuntu.yml
@@ -22,7 +22,7 @@
     executable: /bin/bash
   changed_when: false
   register: ubuntu_architecture
-  when: haproxy_version is not defined
+  when: haproxy_version == "latest"
 
 - name: Find latest version of HAProxy
   ansible.builtin.script: files/find_latest_haproxy.py --ubuntu-release-name "{{ ansible_facts['distribution_release'] }}" --ubuntu-architecture "{{ ubuntu_architecture.stdout }}"
@@ -30,12 +30,12 @@
     executable: python3
   changed_when: false
   register: haproxy_version_result
-  when: haproxy_version is not defined
+  when: haproxy_version == "latest"
 
 - name: Set HAProxy version
   ansible.builtin.set_fact:
     haproxy_version: "{{ haproxy_version_result.stdout_lines[0] }}"
-  when: haproxy_version is not defined
+  when: haproxy_version == "latest"
 
 - name: Check if PPA present - vbernat/haproxy-{{ haproxy_version }}
   ansible.builtin.shell: |

--- a/tasks/setup-Ubuntu.yml
+++ b/tasks/setup-Ubuntu.yml
@@ -8,7 +8,7 @@
 
 - name: Set HAProxy version
   ansible.builtin.set_fact:
-    haproxy_version: "{{ haproxy_version_result.stdout }}"
+    haproxy_version: "{{ haproxy_version_result.stdout_lines[0] }}"
   when: haproxy_version is not defined or haproxy_version == 'latest'
 
 - name: Display a variable

--- a/tasks/setup-Ubuntu.yml
+++ b/tasks/setup-Ubuntu.yml
@@ -4,12 +4,12 @@
   args:
     executable: python3
   register: haproxy_version_result
-  when: haproxy_version is not defined or haproxy_version == 'latest'
+  when: haproxy_version is not defined
 
 - name: Set HAProxy version
   ansible.builtin.set_fact:
     haproxy_version: "{{ haproxy_version_result.stdout_lines[0] }}"
-  when: haproxy_version is not defined or haproxy_version == 'latest'
+  when: haproxy_version is not defined
 
 - name: Check if PPA present - vbernat/haproxy-{{ haproxy_version }}
   ansible.builtin.shell: |

--- a/tasks/setup-Ubuntu.yml
+++ b/tasks/setup-Ubuntu.yml
@@ -21,6 +21,7 @@
   ansible.builtin.script: files/find_latest_haproxy.py --ubuntu-release-name "{{ ansible_facts['distribution_release'] }}" --ubuntu-architecture "{{ ubuntu_architecture.stdout }}"
   args:
     executable: python3
+  changed_when: false
   register: haproxy_version_result
   when: haproxy_version is not defined
 

--- a/tasks/setup-Ubuntu.yml
+++ b/tasks/setup-Ubuntu.yml
@@ -1,0 +1,30 @@
+---
+- name: Find latest version of HAProxy
+  ansible.builtin.script: files\find_latest_haproxy.py
+  args:
+    executable: python3
+  register: haproxy_version_result
+  when: haproxy_version is not defined or haproxy_version == 'latest'
+
+- name: Set HAProxy version
+  ansible.builtin.set_fact:
+    haproxy_version: "{{ haproxy_version_result.stdout }}"
+  when: haproxy_version is not defined or haproxy_version == 'latest'
+
+- name: Display a variable
+  debug:
+    var: haproxy_version
+# - name: Check if PPA present - vbernat/haproxy-{{ haproxy_version }}
+#   ansible.builtin.shell: |
+#     set -o pipefail
+#     add-apt-repository --list | grep vbernat/haproxy-{{ haproxy_version }}
+#   args:
+#     executable: /bin/bash
+#   failed_when: haproxy_repo_present.rc not in [0,1]
+#   changed_when: false
+#   register: haproxy_repo_present
+
+# - name: Add PPA vbernat/haproxy-{{ haproxy_version }}
+#   ansible.builtin.command: add-apt-repository ppa:vbernat/haproxy-{{ haproxy_version }} -y
+#   changed_when: true
+#   when: haproxy_repo_present.stdout == ''

--- a/tasks/setup-Ubuntu.yml
+++ b/tasks/setup-Ubuntu.yml
@@ -11,20 +11,17 @@
     haproxy_version: "{{ haproxy_version_result.stdout_lines[0] }}"
   when: haproxy_version is not defined or haproxy_version == 'latest'
 
-- name: Display a variable
-  debug:
-    var: haproxy_version
-# - name: Check if PPA present - vbernat/haproxy-{{ haproxy_version }}
-#   ansible.builtin.shell: |
-#     set -o pipefail
-#     add-apt-repository --list | grep vbernat/haproxy-{{ haproxy_version }}
-#   args:
-#     executable: /bin/bash
-#   failed_when: haproxy_repo_present.rc not in [0,1]
-#   changed_when: false
-#   register: haproxy_repo_present
+- name: Check if PPA present - vbernat/haproxy-{{ haproxy_version }}
+  ansible.builtin.shell: |
+    set -o pipefail
+    add-apt-repository --list | grep vbernat/haproxy-{{ haproxy_version }}
+  args:
+    executable: /bin/bash
+  failed_when: haproxy_repo_present.rc not in [0,1]
+  changed_when: false
+  register: haproxy_repo_present
 
-# - name: Add PPA vbernat/haproxy-{{ haproxy_version }}
-#   ansible.builtin.command: add-apt-repository ppa:vbernat/haproxy-{{ haproxy_version }} -y
-#   changed_when: true
-#   when: haproxy_repo_present.stdout == ''
+- name: Add PPA vbernat/haproxy-{{ haproxy_version }}
+  ansible.builtin.command: add-apt-repository ppa:vbernat/haproxy-{{ haproxy_version }} -y
+  changed_when: true
+  when: haproxy_repo_present.stdout == ''

--- a/tasks/setup-Ubuntu.yml
+++ b/tasks/setup-Ubuntu.yml
@@ -1,6 +1,6 @@
 ---
 - name: Find latest version of HAProxy
-  ansible.builtin.script: files/find_latest_haproxy.py
+  ansible.builtin.script: files/find_latest_haproxy.py --ubuntu-release-name "{{ ansible_facts['distribution_release'] }}"
   args:
     executable: python3
   register: haproxy_version_result

--- a/tasks/setup-Ubuntu.yml
+++ b/tasks/setup-Ubuntu.yml
@@ -34,7 +34,7 @@
 
 - name: Set HAProxy version
   ansible.builtin.set_fact:
-    haproxy_version: "{{ haproxy_version_result.stdout_lines[0] }}"
+    haproxy_version: "{{ haproxy_version_result.stdout_lines[0] | trim }}"
   when: haproxy_version == "latest"
 
 - name: Check if PPA present - vbernat/haproxy-{{ haproxy_version }}

--- a/tasks/setup-Ubuntu.yml
+++ b/tasks/setup-Ubuntu.yml
@@ -15,6 +15,7 @@
     executable: /bin/bash
   changed_when: false
   register: ubuntu_architecture
+  when: haproxy_version is not defined
 
 - name: Find latest version of HAProxy
   ansible.builtin.script: files/find_latest_haproxy.py --ubuntu-release-name "{{ ansible_facts['distribution_release'] }}" --ubuntu-architecture "{{ ubuntu_architecture.stdout }}"

--- a/tasks/setup-Ubuntu.yml
+++ b/tasks/setup-Ubuntu.yml
@@ -1,6 +1,6 @@
 ---
 - name: Find latest version of HAProxy
-  ansible.builtin.script: files\find_latest_haproxy.py
+  ansible.builtin.script: files/find_latest_haproxy.py
   args:
     executable: python3
   register: haproxy_version_result

--- a/tasks/setup-Ubuntu.yml
+++ b/tasks/setup-Ubuntu.yml
@@ -1,6 +1,23 @@
 ---
+- name: Set CPU architecture
+  ansible.builtin.shell: |
+    set -o pipefail -e
+
+    architecture="{{ ansible_architecture }}"
+    if [[ "$architecture" == "x86_64" ]]; then
+      echo "amd64"
+    elif [[ "$architecture" == "aarch64" ]]; then
+      echo "arm64"
+    elif [[ "$architecture" == "i386" ]]; then
+      echo "i386"
+    fi
+  args:
+    executable: /bin/bash
+  changed_when: false
+  register: ubuntu_architecture
+
 - name: Find latest version of HAProxy
-  ansible.builtin.script: files/find_latest_haproxy.py --ubuntu-release-name "{{ ansible_facts['distribution_release'] }}"
+  ansible.builtin.script: files/find_latest_haproxy.py --ubuntu-release-name "{{ ansible_facts['distribution_release'] }}" --ubuntu-architecture "{{ ubuntu_architecture.stdout }}"
   args:
     executable: python3
   register: haproxy_version_result

--- a/tasks/setup-Ubuntu.yml
+++ b/tasks/setup-Ubuntu.yml
@@ -1,4 +1,11 @@
 ---
+- name: Ensure dependencies are installed
+  ansible.builtin.apt:
+    name: software-properties-common
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
 - name: Set CPU architecture
   ansible.builtin.shell: |
     set -o pipefail -e


### PR DESCRIPTION
# Pull Request Description
- Enable option to automatically install the latest version of HaProxy available
- Move all Ubuntu specific tasks into one include
- Allow downgrade of HaProxy version

## Change type
- [ ] Bug fix (non-breaking change which fixes a specific issue)
- [x] New feature (non-breaking change adding new functionality)
- [ ] Breaking change (fix or feature that potentially causes existing functionality to fail)
- [ ] Change that does not affect Ansible Role code (Github Actions Workflow, Documentation, or similair)

## How was this tested?
Tested on:
- Ubuntu 20.04
- Ubuntu 22.04
- Ubuntu 24.04